### PR TITLE
fix: typo in rest-api_JP.md

### DIFF
--- a/rest-api_JP.md
+++ b/rest-api_JP.md
@@ -157,7 +157,7 @@ GET /user/spot/order
 
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
-pair | string | YES | 通貨ペア: `btc_jpy`, `xrp_jpy`, `xrp_btc`, `ltc_jpy`, `ltc_btc`, `eth_jpy`, `eth_btc`, `mona_jpy`, `mona_btc`, `bcc_jpy`, `bcc_btc
+pair | string | YES | 通貨ペア: `btc_jpy`, `xrp_jpy`, `xrp_btc`, `ltc_jpy`, `ltc_btc`, `eth_jpy`, `eth_btc`, `mona_jpy`, `mona_btc`, `bcc_jpy`, `bcc_btc`
 order_id | number | YES | 取引ID
 
 **Response:**


### PR DESCRIPTION
Fix: typo in rest-api_JP.md

In the Description of the Parameters of the "注文情報を取得する" endpoint, `bcc_btc` was not enclosed in backquotes.

## Screenshots (if appropriate):
![スクリーンショット_2020-08-28_23_59_48](https://user-images.githubusercontent.com/1546218/91582349-a7e85000-e98a-11ea-867c-e4a3df948c33.png)
