### PR TITLE
feat(rest-api): add max count limit to GET /user/spot/trade_history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# CHANGELOG for Bitbank's API (2020-11-20)
+# CHANGELOG for Bitbank's API (2020-12-23)
+---
+## 2020-12-23
+* Added `count` limitation of "Fetch trade history" endpoint to `rest-api.md` and `rest-api_JP.md` ([#19](https://github.com/bitbankinc/bitbank-api-docs/issues/19))
+
 ---
 ## 2020-11-20
 * Added some missing error codes to `errors.md`

--- a/rest-api.md
+++ b/rest-api.md
@@ -544,11 +544,11 @@ GET /user/spot/trade_history
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
 pair | string | YES | pair enum: `btc_jpy`, `xrp_jpy`, `xrp_btc`, `ltc_jpy`, `ltc_btc`, `eth_jpy`, `eth_btc`, `mona_jpy`, `mona_btc`, `bcc_jpy`, `bcc_btc`, `xlm_jpy`, `xlm_btc`
-count | number | NO |take limit
+count | number | NO | take limit (up to 1000)
 order_id | number | NO | order id
 since | number | NO | since unix timestamp
 end | number | NO | emd unix timestamp
-order | string | NO | histories in order(order enum: `asc`or `desc`, default to `desc`)
+order | string | NO | histories in order(order enum: `asc` or `desc`, default to `desc`)
 
 **Response:**
 

--- a/rest-api_JP.md
+++ b/rest-api_JP.md
@@ -531,7 +531,7 @@ GET /user/spot/trade_history
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
 pair | string | YES | 通貨ペア: `btc_jpy`, `xrp_jpy`, `xrp_btc`, `ltc_jpy`, `ltc_btc`, `eth_jpy`, `eth_btc`, `mona_jpy`, `mona_btc`, `bcc_jpy`, `bcc_btc`, `xlm_jpy`, `xlm_btc`
-count | number | NO | 取得する約定数
+count | number | NO | 取得する約定数(最大1000)
 order_id | number | NO | 注文ID
 since | number | NO | 開始UNIXタイムスタンプ
 end | number | NO | 終了UNIXタイムスタンプ


### PR DESCRIPTION
## Description
added limitation to `GET /user/spot/trade_history` 's count parameter to clarify.

## Related Issue
#19

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
