### PR TITLE
fix(public-api): add missing 1month for candle-type of candlestick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# CHANGELOG for Bitbank's API (2020-12-23)
+# CHANGELOG for Bitbank's API (2020-12-25)
+---
+## 2020-12-25
+* Added missing 1month for candle-type of candlestick to `public-api.md` and `public-api_JP.md`
+
 ---
 ## 2020-12-23
 * Added `count` limitation of "Fetch trade history" endpoint to `rest-api.md` and `rest-api_JP.md` ([#19](https://github.com/bitbankinc/bitbank-api-docs/issues/19))

--- a/public-api.md
+++ b/public-api.md
@@ -176,12 +176,12 @@ GET /{pair}/candlestick/{candle-type}/{YYYY}
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
 pair | string | YES | pair enum: `btc_jpy`, `xrp_jpy`, `xrp_btc`, `ltc_jpy`, `ltc_btc`, `eth_jpy`, `eth_btc`, `mona_jpy`, `mona_btc`, `bcc_jpy`, `bcc_btc`, `xlm_jpy`, `xlm_btc`
-candle-type | string | YES | candle type enum: `1min`, `5min`, `15min`, `30min`, `1hour`, `4hour`, `8hour`, `12hour`, `1day`, `1week`
+candle-type | string | YES | candle type enum: `1min`, `5min`, `15min`, `30min`, `1hour`, `4hour`, `8hour`, `12hour`, `1day`, `1week`, `1month`
 YYYY | string | YES | date formatted as `YYYY` or  `YYYYMMDD`
 
 - YYYY Format depends on the candle-type:
   - `YYYYMMDD`: `1min`, `5min`, `15min`, `30min`, `1hour`
-  - `YYYY`: `4hour`, `8hour`, `12hour`, `1day`, `1week`
+  - `YYYY`: `4hour`, `8hour`, `12hour`, `1day`, `1week`, `1month`
 
 **Response:**
 

--- a/public-api_JP.md
+++ b/public-api_JP.md
@@ -176,12 +176,12 @@ GET /{pair}/candlestick/{candle-type}/{YYYY}
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
 pair | string | YES | 通貨ペア: `btc_jpy`, `xrp_jpy`, `xrp_btc`, `ltc_jpy`, `ltc_btc`, `eth_jpy`, `eth_btc`, `mona_jpy`, `mona_btc`, `bcc_jpy`, `bcc_btc`, `xlm_jpy`, `xlm_btc`
-candle-type | string | YES | 以下の期間から指定: `1min`, `5min`, `15min`, `30min`, `1hour`, `4hour`, `8hour`, `12hour`, `1day`, `1week`
+candle-type | string | YES | 以下の期間から指定: `1min`, `5min`, `15min`, `30min`, `1hour`, `4hour`, `8hour`, `12hour`, `1day`, `1week`, `1month`
 YYYY | string | YES | 日付 `YYYYMMDD` 形式または `YYYY` を指定
 
 - YYYY の指定は candle-type によって異なります:
   - `YYYYMMDD`: `1min`, `5min`, `15min`, `30min`, `1hour`
-  - `YYYY`: `4hour`, `8hour`, `12hour`, `1day`, `1week`
+  - `YYYY`: `4hour`, `8hour`, `12hour`, `1day`, `1week`, `1month`
 
 **Response:**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add missing 1month for candle-type of candlestick, that can be retrieved but not documented.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
curl https://public.bitbank.cc/btc_jpy/candlestick/1month/2020
curl https://public.bitbank.cc/xlm_btc/candlestick/1month/2020
```

## Screenshots (if appropriate):
