### PR TITLE
fix: remove wrong JPYTickers pair

### DIFF
--- a/public-api.md
+++ b/public-api.md
@@ -143,7 +143,7 @@ nothing
 
 Name | Type | Description
 ------------ | ------------ | ------------
-pair | string | JPY pair enum: `btc_jpy`, `xrp_jpy`, `ltc_jpy`, `eth_jpy`, `mona_jpy`, `bcc_jpy`, `xlm_jpy`, `qtum_jpy`, `bat_jpy`, `omg_jpy`, `xym_jpy`, `xym_btc`
+pair | string | JPY pair enum: `btc_jpy`, `xrp_jpy`, `ltc_jpy`, `eth_jpy`, `mona_jpy`, `bcc_jpy`, `xlm_jpy`, `qtum_jpy`, `bat_jpy`, `omg_jpy`, `xym_jpy`
 sell | string | the lowest price of sell orders
 buy | string | the highest price of buy orders
 high | string | the highest price in last 24 hours

--- a/public-api_JP.md
+++ b/public-api_JP.md
@@ -143,7 +143,7 @@ GET /tickers_jpy
 
 Name | Type | Description
 ------------ | ------------ | ------------
-pair | string | 通貨ペア(JPYペアのみ): `btc_jpy`, `xrp_jpy`, `ltc_jpy`, `eth_jpy`, `mona_jpy`, `bcc_jpy`, `xlm_jpy`, `qtum_jpy`, `bat_jpy`, `omg_jpy`, `xym_jpy`, `xym_btc`
+pair | string | 通貨ペア(JPYペアのみ): `btc_jpy`, `xrp_jpy`, `ltc_jpy`, `eth_jpy`, `mona_jpy`, `bcc_jpy`, `xlm_jpy`, `qtum_jpy`, `bat_jpy`, `omg_jpy`, `xym_jpy`
 sell | string | 現在の売り注文の最安値
 buy | string | 現在の買い注文の最高値
 high | string | 過去24時間の最高値取引価格


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

JPYTickers API  returns JPY currency pairs only
