### PR TITLE
fix: header of pairs table

### DIFF
--- a/pairs.md
+++ b/pairs.md
@@ -10,7 +10,7 @@
 
 The following is the list of pair.
 
-Symbol | Quote asset | Base asset | Order suspended flag (delisted)
+Symbol | Base asset | Quote asset | Order suspended flag (delisted)
 ------------ | ------------ | ------------ | ------------
 btc_jpy | btc | jpy | false
 xrp_jpy | xrp | jpy | false


### PR DESCRIPTION
## Description
Replace the headings "Quote asset" and "Base asset" in the table of pairs.

## Related Issue
#104 

## How Has This Been Tested?
No testing due to modification of documentation.

## Screenshots (if appropriate):
