### PR TITLE
[doc] 40 should be sent by client

### DIFF
--- a/public-stream.md
+++ b/public-stream.md
@@ -57,7 +57,7 @@ $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 
 connected (press CTRL+C to quit)
 < 0{"sid":"bDAf6vgk5xPau87WAA1u","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","ticker_btc_jpy"]
 < 42["message",{"room_name":"ticker_btc_jpy","message":{"pid":851203833,"data":{"sell":"896490","buy":"896489","open":"896489","high":"905002","low":"881500","last":"896489","vol":"650.2026","timestamp":1570080042822}}}]
 < 42["message",{"room_name":"ticker_btc_jpy","message":{"pid":851203952,"data":{"sell":"896490","buy":"896489","open":"896489","high":"905002","low":"881500","last":"896489","vol":"650.2226","timestamp":1570080053768}}}]
@@ -118,7 +118,7 @@ $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 
 connected (press CTRL+C to quit)
 < 0{"sid":"PG3FbI0WrKIP7hKMABH_","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","transactions_xrp_jpy"]
 < 42["message",{"room_name":"transactions_xrp_jpy","message":{"pid":851205254,"data":{"transactions":[{"transaction_id":34745047,"side":"sell","price":"26.930","amount":"4703.5671","executed_at":1570080162855},{"transaction_id":34745046,"side":"sell","price":"26.930","amount":"500.0000","executed_at":1570080162829},{"transaction_id":34745045,"side":"sell","price":"26.930","amount":"378.0000","executed_at":1570080162802},{"transaction_id":34745044,"side":"sell","price":"26.930","amount":"12.0000","executed_at":1570080162758},{"transaction_id":34745043,"side":"sell","price":"26.930","amount":"301.4874","executed_at":1570080162725}]}}}]
 ...
@@ -189,7 +189,7 @@ For usage, see [How to manage a local order book correctly](#how-to-manage-a-loc
 $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 connected (press CTRL+C to quit)
 < 0{"sid":"9-zd3P1G-BNu_w37ABMX","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","depth_diff_xrp_jpy"]
 < 42["message",{"room_name":"depth_diff_xrp_jpy","message":{"data":{"a":[],"b":[["26.758","20000.0000"],["26.212","0"]],"t":1570080269609,"s":"1234567890"}}}]
 < 42["message",{"room_name":"depth_diff_xrp_jpy","message":{"data":{"a":[],"b":[["26.212","1000.0000"],["26.815","0"]],"t":1570080270100,"s":"1234567893"}}}]
@@ -273,7 +273,7 @@ For usage, see [How to manage a local order book correctly](#how-to-manage-a-loc
 $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 connected (press CTRL+C to quit)
 < 0{"sid":"PR6GLrwlEFjzHIPrABBM","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","depth_whole_xrp_jpy"]
 < 42["message",{"room_name":"depth_whole_xrp_jpy","message":{"data":{"asks":[["26.928","1000.0000"],["26.929","56586.5153"],["26.930","218.3431"],["26.931","3123.8845"],["26.933","1799.0000"],["26.934","377.9136"],["26.938","3411.1507"],["26.950","80.0000"],["26.955","80.0000"],["26.958","7434.5900"],["26.959","15000.0000"],["26.960","15000.0000"],["26.964","10837.6620"],["26.979","15000.0000"], ...
 
@@ -355,7 +355,7 @@ $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 
 connected (press CTRL+C to quit)
 < 0{"sid":"PG3FbI0WrKIP7hKMABH_","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","circuit_break_info_xrp_jpy"]
 < 42["message",{"room_name":"circuit_break_info_xrp_jpy","message":{"data":{"mode":"NONE","estimated_itayose_price":null,"estimated_itayose_amount":null,"itayose_upper_price":null,"itayose_lower_price":null,"upper_trigger_price":"1200000","lower_trigger_price":"800000","fee_type":"NORMAL","reopen_timestamp":null,"timestamp":1570080162855}}}]
 < 42["message",{"room_name":"circuit_break_info_xrp_jpy","message":{"data":{"mode":"CIRCUIT_BREAK","estimated_itayose_price":"1000000","estimated_itayose_amount":null,"itayose_upper_price":"1300000","itayose_lower_price":"800000","upper_trigger_price":null,"lower_trigger_price":null,"fee_type":"SELL_MAKER","reopen_timestamp":1234573890000,"timestamp":1570080162856}}}]

--- a/public-stream_JP.md
+++ b/public-stream_JP.md
@@ -59,7 +59,7 @@ $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 
 connected (press CTRL+C to quit)
 < 0{"sid":"bDAf6vgk5xPau87WAA1u","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","ticker_btc_jpy"]
 < 42["message",{"room_name":"ticker_btc_jpy","message":{"pid":851203833,"data":{"sell":"896490","buy":"896489","open":"896489","high":"905002","low":"881500","last":"896489","vol":"650.2026","timestamp":1570080042822}}}]
 < 42["message",{"room_name":"ticker_btc_jpy","message":{"pid":851203952,"data":{"sell":"896490","buy":"896489","open":"896489","high":"905002","low":"881500","last":"896489","vol":"650.2226","timestamp":1570080053768}}}]
@@ -122,7 +122,7 @@ $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 
 connected (press CTRL+C to quit)
 < 0{"sid":"PG3FbI0WrKIP7hKMABH_","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","transactions_xrp_jpy"]
 < 42["message",{"room_name":"transactions_xrp_jpy","message":{"pid":851205254,"data":{"transactions":[{"transaction_id":34745047,"side":"sell","price":"26.930","amount":"4703.5671","executed_at":1570080162855},{"transaction_id":34745046,"side":"sell","price":"26.930","amount":"500.0000","executed_at":1570080162829},{"transaction_id":34745045,"side":"sell","price":"26.930","amount":"378.0000","executed_at":1570080162802},{"transaction_id":34745044,"side":"sell","price":"26.930","amount":"12.0000","executed_at":1570080162758},{"transaction_id":34745043,"side":"sell","price":"26.930","amount":"301.4874","executed_at":1570080162725}]}}}]
 ...
@@ -194,7 +194,7 @@ s | string | シーケンスID、単調増加しますが連続していると�
 $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 connected (press CTRL+C to quit)
 < 0{"sid":"9-zd3P1G-BNu_w37ABMX","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","depth_diff_xrp_jpy"]
 < 42["message",{"room_name":"depth_diff_xrp_jpy","message":{"data":{"a":[],"b":[["26.758","20000.0000"],["26.212","0"]],"t":1570080269609,"s":"1234567890"}}}]
 < 42["message",{"room_name":"depth_diff_xrp_jpy","message":{"data":{"a":[],"b":[["26.212","1000.0000"],["26.815","0"]],"t":1570080270100,"s":"1234567893"}}}]
@@ -280,7 +280,7 @@ sequenceId | string | シーケンスID、単調増加しますが連続して�
 $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 connected (press CTRL+C to quit)
 < 0{"sid":"PR6GLrwlEFjzHIPrABBM","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","depth_whole_xrp_jpy"]
 < 42["message",{"room_name":"depth_whole_xrp_jpy","message":{"data":{"asks":[["26.928","1000.0000"],["26.929","56586.5153"],["26.930","218.3431"],["26.931","3123.8845"],["26.933","1799.0000"],["26.934","377.9136"],["26.938","3411.1507"],["26.950","80.0000"],["26.955","80.0000"],["26.958","7434.5900"],["26.959","15000.0000"],["26.960","15000.0000"],["26.964","10837.6620"],["26.979","15000.0000"], ...
 
@@ -362,7 +362,7 @@ $ wscat -c 'wss://stream.bitbank.cc/socket.io/?EIO=4&transport=websocket'
 
 connected (press CTRL+C to quit)
 < 0{"sid":"PG3FbI0WrKIP7hKMABH_","upgrades":[],"pingInterval":25000,"pingTimeout":60000}
-< 40
+> 40
 > 42["join-room","circuit_break_info_xrp_jpy"]
 < 42["message",{"room_name":"circuit_break_info_xrp_jpy","message":{"data":{"mode":"NONE","estimated_itayose_price":null,"estimated_itayose_amount":null,"itayose_upper_price":null,"itayose_lower_price":null,"upper_trigger_price":"1200000","lower_trigger_price":"800000","fee_type":"NORMAL","reopen_timestamp":null,"timestamp":1570080162855}}}]
 < 42["message",{"room_name":"circuit_break_info_xrp_jpy","message":{"data":{"mode":"CIRCUIT_BREAK","estimated_itayose_price":"1000000","estimated_itayose_amount":null,"itayose_upper_price":"1300000","itayose_lower_price":"800000","upper_trigger_price":null,"lower_trigger_price":null,"fee_type":"SELL_MAKER","reopen_timestamp":1234573890000,"timestamp":1570080162856}}}]


### PR DESCRIPTION
We accept pull-requests for Bug Fixes **ONLY**.

<!--- Provide a general summary of your changes in the Title above -->

## Description
In the sample codes for public-stream, it is written like `40` is sent from server although it needs be sent by the client.

This is an actual log when I tried.
```
< 0{"sid":"2pDgd3DMjwoOFXUkZ1tn","upgrades":[],"pingInterval":25000,"pingTimeout":20000,"maxPayload":1000000}
> 40
< 40{"sid":"2D6xeZquKvQrMQBBZ1ty"}
> 42["join-room","ticker_btc_jpy"]
< 42["message",{"room_name":"ticker_btc_jpy","message":{"data":{"sell":"9730376","buy":"9730000","open":"9838887","high":"10000799","low":"9682588","last":"9732000","vol":"154.1316","timestamp":1711264865809}}}]
```

To reviewer: Please add a line corresponding to `< 40{"sid":"2D6xeZquKvQrMQBBZ1ty"}` if you like.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
This PR is only changing docs. No need to test it.

## Screenshots (if appropriate):
