### PR TITLE
feat: history get multiple asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-# CHANGELOG for Bitbank's API (2025-12-22)
+# CHANGELOG for Bitbank's API (2025-12-23)
 
+## 2025-12-23
+* Updated docs
+  * `rest-api.md`
+  * `rest-api_JP.md`
+
+---
 ## 2025-12-22
 * Updated docs
   * `rest-api.md`

--- a/rest-api.md
+++ b/rest-api.md
@@ -999,7 +999,7 @@ GET /user/deposit_history
 
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
-asset | string | YES | enum: [asset list](assets.md)
+asset | string | NO | enum: [asset list](assets.md)
 count | number | NO | take limit (up to 100)
 since | number | NO | since unix timestamp
 end | number | NO | end unix timestamp
@@ -1020,6 +1020,8 @@ confirmed_at | number | confirmed (about to be added to your balance) at unix ti
 
 **Caveat:**
 
+* If you do not specify the asset parameter, the deposit history for all crypto assets will be returned.
+* To retrieve the history in JPY, set the `asset` parameter to `jpy`.
 * The deposit history response currently does not contain destination tag, memo and bank account. Use txid for matching asset flows with other systems.
 
 **Sample code:**
@@ -1032,9 +1034,9 @@ confirmed_at | number | confirmed (about to be added to your balance) at unix ti
 export API_KEY=___your api key___
 export API_SECRET=___your api secret___
 export ACCESS_NONCE="$(date +%s)000"
-export ACCESS_SIGNATURE="$(echo -n "$ACCESS_NONCE/v1/user/deposit_history?asset=btc" | openssl dgst -sha256 -hmac "$API_SECRET" | awk '{print $NF}')"
+export ACCESS_SIGNATURE="$(echo -n "$ACCESS_NONCE/v1/user/deposit_history" | openssl dgst -sha256 -hmac "$API_SECRET" | awk '{print $NF}')"
 
-curl -H "ACCESS-KEY: $API_KEY" -H "ACCESS-NONCE: $ACCESS_NONCE" -H "ACCESS-SIGNATURE: $ACCESS_SIGNATURE" "https://api.bitbank.cc/v1/user/deposit_history?asset=btc"
+curl -H "ACCESS-KEY: $API_KEY" -H "ACCESS-NONCE: $ACCESS_NONCE" -H "ACCESS-SIGNATURE: $ACCESS_SIGNATURE" "https://api.bitbank.cc/v1/user/deposit_history"
 ```
 
 </p>
@@ -1484,7 +1486,7 @@ GET /user/withdrawal_history
 
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
-asset | string | YES | enum: [asset list](assets.md)
+asset | string | NO | enum: [asset list](assets.md)
 count | number | NO | take limit (up to 100)
 since | number | NO | since unix timestamp
 end | number | NO | end unix timestamp
@@ -1511,6 +1513,11 @@ account_owner | string | owner of withdrawal account (only for fiat assets)
 status | string | withdrawal status enum: `CONFIRMING`, `EXAMINING`, `SENDING`,  `DONE`, `REJECTED`, `CANCELED`, `CONFIRM_TIMEOUT`
 requested_at | number | requested at unix timestamp (milliseconds)
 
+**Caveat:**
+
+* If you do not specify the asset parameter, the withdrawal history for all crypto assets will be returned.
+* To retrieve the history in JPY, set the `asset` parameter to `jpy`.
+
 **Sample code:**
 
 <details>
@@ -1520,10 +1527,10 @@ requested_at | number | requested at unix timestamp (milliseconds)
 ```sh
 export API_KEY=___your api key___
 export API_SECRET=___your api secret___
-export ACCESS_NONCE="$(date +%s)000"
-export ACCESS_SIGNATURE="$(echo -n "$ACCESS_NONCE/v1/user/withdrawal_history?asset=btc" | openssl dgst -sha256 -hmac "$API_SECRET" | awk '{print $NF}')"
+export ACCESS_NONCE="$(date +%s)"
+export ACCESS_SIGNATURE="$(echo -n "$ACCESS_NONCE/v1/user/withdrawal_history" | openssl dgst -sha256 -hmac "$API_SECRET")"
 
-curl -H "ACCESS-KEY: $API_KEY" -H "ACCESS-NONCE: $ACCESS_NONCE" -H "ACCESS-SIGNATURE: $ACCESS_SIGNATURE" "https://api.bitbank.cc/v1/user/withdrawal_history?asset=btc"
+curl -H "ACCESS-KEY: $API_KEY" -H "ACCESS-NONCE: $ACCESS_NONCE" -H "ACCESS-SIGNATURE: $ACCESS_SIGNATURE" "https://api.bitbank.cc/v1/user/withdrawal_history"
 ```
 
 </p>

--- a/rest-api_JP.md
+++ b/rest-api_JP.md
@@ -1007,7 +1007,7 @@ GET /user/deposit_history
 
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
-asset | string | YES | アセット名: [アセット一覧](assets.md)
+asset | string | NO | アセット名: [アセット一覧](assets.md)
 count | number | NO | 取得する履歴数(最大100)
 since | number | NO | 開始UNIXタイムスタンプ(ミリ秒)
 end | number | NO | 終了UNIXタイムスタンプ(ミリ秒)
@@ -1028,6 +1028,8 @@ confirmed_at | number | 承認(残高追加確定時)UNIXタイムスタンプ(�
 
 **注意事項:**
 
+* `asset`を指定しなかった場合は全ての暗号資産の履歴を取得します。
+* 日本円の履歴を取得する場合は`aseet`に`jpy`を指定してください。
 * 現時点では入金履歴レスポンスには宛先タグ、メモおよび銀行口座情報が含まれていません。他システムの送金・送信との突合にはtxidをお使いください。
 
 **サンプルコード:**
@@ -1039,10 +1041,10 @@ confirmed_at | number | 承認(残高追加確定時)UNIXタイムスタンプ(�
 ```sh
 export API_KEY=___your api key___
 export API_SECRET=___your api secret___
-export ACCESS_NONCE="$(date +%s)000"
-export ACCESS_SIGNATURE="$(echo -n "$ACCESS_NONCE/v1/user/deposit_history?asset=btc" | openssl dgst -sha256 -hmac "$API_SECRET" | awk '{print $NF}')"
+export ACCESS_NONCE="$(date +%s)"
+export ACCESS_SIGNATURE="$(echo -n "$ACCESS_NONCE/v1/user/deposit_history" | openssl dgst -sha256 -hmac "$API_SECRET")"
 
-curl -H "ACCESS-KEY: $API_KEY" -H "ACCESS-NONCE: $ACCESS_NONCE" -H "ACCESS-SIGNATURE: $ACCESS_SIGNATURE" "https://api.bitbank.cc/v1/user/deposit_history?asset=btc"
+curl -H "ACCESS-KEY: $API_KEY" -H "ACCESS-NONCE: $ACCESS_NONCE" -H "ACCESS-SIGNATURE: $ACCESS_SIGNATURE" "https://api.bitbank.cc/v1/user/deposit_history"
 ```
 
 </p>
@@ -1492,7 +1494,7 @@ GET /user/withdrawal_history
 
 Name | Type | Mandatory | Description
 ------------ | ------------ | ------------ | ------------
-asset | string | YES | アセット名: [アセット一覧](assets.md)
+asset | string | NO | アセット名: [アセット一覧](assets.md)
 count | number | NO | 取得する履歴数(最大100)
 since | number | NO | 開始UNIXタイムスタンプ(ミリ秒)
 end | number | NO | 終了UNIXタイムスタンプ(ミリ秒)
@@ -1519,6 +1521,11 @@ account_owner | string | 出金先口座名義(法定通貨の時のみ)
 status | string | `CONFIRMING`, `EXAMINING`, `SENDING`,  `DONE`, `REJECTED`, `CANCELED`, `CONFIRM_TIMEOUT`
 requested_at | number | リクエスト日時UNIXタイムスタンプ(ミリ秒)
 
+**注意事項:**
+
+* `asset`を指定しなかった場合は全ての暗号資産の履歴を取得します。
+* 日本円の履歴を取得する場合は`aseet`に`jpy`を指定してください。
+
 **サンプルコード:**
 
 <details>
@@ -1528,10 +1535,10 @@ requested_at | number | リクエスト日時UNIXタイムスタンプ(ミリ秒
 ```sh
 export API_KEY=___your api key___
 export API_SECRET=___your api secret___
-export ACCESS_NONCE="$(date +%s)000"
-export ACCESS_SIGNATURE="$(echo -n "$ACCESS_NONCE/v1/user/withdrawal_history?asset=btc" | openssl dgst -sha256 -hmac "$API_SECRET" | awk '{print $NF}')"
+export ACCESS_NONCE="$(date +%s)"
+export ACCESS_SIGNATURE="$(echo -n "$ACCESS_NONCE/v1/user/withdrawal_history" | openssl dgst -sha256 -hmac "$API_SECRET")"
 
-curl -H "ACCESS-KEY: $API_KEY" -H "ACCESS-NONCE: $ACCESS_NONCE" -H "ACCESS-SIGNATURE: $ACCESS_SIGNATURE" "https://api.bitbank.cc/v1/user/withdrawal_history?asset=btc"
+curl -H "ACCESS-KEY: $API_KEY" -H "ACCESS-NONCE: $ACCESS_NONCE" -H "ACCESS-SIGNATURE: $ACCESS_SIGNATURE" "https://api.bitbank.cc/v1/user/withdrawal_history"
 ```
 
 </p>


### PR DESCRIPTION
deposit history,withdrawal historyを取得する際に通貨を指定しない場合、全暗号資産の履歴を取得できるように変更
- 対象エンドポイント
    - GET /v1/user/deposit_history
    - GET /v1/user/withdrawal_history